### PR TITLE
Don't intervene with non-AWS HTTP authentication

### DIFF
--- a/swift3/request.py
+++ b/swift3/request.py
@@ -76,7 +76,7 @@ class Request(swob.Request):
             raise AccessDenied()
 
         if keyword != 'AWS':
-            raise AccessDenied()
+            raise NotS3Request
 
         try:
             access_key, signature = info.rsplit(':', 1)


### PR DESCRIPTION
The HTTP Authorization header is a general purpose header, which also has applications for http basic and digest authentications. Treating all non-AWS authentication as a broken S3 request is the wrong thing to do. Instead, just pass it on downstream.
